### PR TITLE
fix: set root as default user as ansible user doesnot necessarly have…

### DIFF
--- a/roles/ssl/defaults/main.yml
+++ b/roles/ssl/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-ssl_certbot_auto_renew_user: "{{ ansible_user }}"
+ssl_certbot_auto_renew_user: root
 ssl_certbot_auto_renew_minute: "0"
 ssl_certbot_auto_renew_hour: "3"
 ssl_certbot_create_if_missing: true


### PR DESCRIPTION
… certbot permissions