### PR TITLE
Each certificate can redefine any global vars

### DIFF
--- a/roles/ssl/README.md
+++ b/roles/ssl/README.md
@@ -35,6 +35,19 @@ ssl_certbot_certs:
       - example2.com
   - domains:
       - api.gouv.fr
+  - domains:
+      - foo.bar
+      - '*.foo.bar'
+    ssl_ovh_dns_api_app_key: ssl_ovh_dns_domains['foo.bar'].api_app_key
+    ssl_ovh_dns_api_app_secret: ssl_ovh_dns_domains['foo.bar'].api_app_secret
+    ssl_ovh_dns_api_consumer_key: ssl_ovh_dns_domains['foo.bar'].api_consumer_key
+    ssl_ovh_zone: foo.bar
+
+    post_hook_script_path: /etc/letsencrypt/renewal-hooks/post/foo.bar
+    post_hook_script: |
+      #!/bin/sh
+
+      docker exec -it nginx sh -c "nginx -s reload"
 ```
 
 ```yaml
@@ -43,4 +56,11 @@ ssl_certbot_certs:
 ssl_ovh_dns_api_app_key: xxx
 ssl_ovh_dns_api_app_secret: xxx
 ssl_ovh_dns_api_consumer_key: xxx
+
+ssl_ovh_dns_domains:
+  foo.bar:
+    api_app_key: xxx
+    api_app_secret: xxx
+    api_consumer_key: xxx
+
 ```

--- a/roles/ssl/README.md
+++ b/roles/ssl/README.md
@@ -38,9 +38,9 @@ ssl_certbot_certs:
   - domains:
       - foo.bar
       - '*.foo.bar'
-    ssl_ovh_dns_api_app_key: ssl_ovh_dns_domains['foo.bar'].api_app_key
-    ssl_ovh_dns_api_app_secret: ssl_ovh_dns_domains['foo.bar'].api_app_secret
-    ssl_ovh_dns_api_consumer_key: ssl_ovh_dns_domains['foo.bar'].api_consumer_key
+    ssl_ovh_dns_api_app_key: "{{ ssl_ovh_dns_domains['foo.bar'].api_app_key }}"
+    ssl_ovh_dns_api_app_secret: "{{ ssl_ovh_dns_domains['foo.bar'].api_app_secret }}"
+    ssl_ovh_dns_api_consumer_key: "{{ ssl_ovh_dns_domains['foo.bar'].api_consumer_key }}"
     ssl_ovh_zone: foo.bar
 
     post_hook_script_path: /etc/letsencrypt/renewal-hooks/post/foo.bar

--- a/roles/ssl/defaults/main.yml
+++ b/roles/ssl/defaults/main.yml
@@ -5,3 +5,4 @@ ssl_certbot_auto_renew_hour: "3"
 ssl_certbot_create_if_missing: true
 ssl_ovh_endpoint: ovh-eu
 ssl_ovh_propagation_seconds: 120
+ssl_reload_nginx_service: true

--- a/roles/ssl/meta/argument_specs.yml
+++ b/roles/ssl/meta/argument_specs.yml
@@ -55,3 +55,8 @@ argument_specs:
         required: false
         default: 120
         description: Self-explanatory
+      ssl_reload_nginx_service:
+        type: bool
+        required: false
+        default: true
+        description: Reload the nginx service when true

--- a/roles/ssl/tasks/main.yml
+++ b/roles/ssl/tasks/main.yml
@@ -31,8 +31,8 @@
     mode: 0755
     dest: "{{ cert_item.post_hook_script_path }}"
   when:
-    - cert_item.ssl_certbot_post_hook_script_path
-    - cert_item.ssl_certbot_post_hook_script
+    - cert_item.post_hook_script_path is defined
+    - cert_item.post_hook_script is defined
   with_items: "{{ ssl_certbot_certs }}"
   loop_control:
     loop_var: cert_item

--- a/roles/ssl/tasks/main.yml
+++ b/roles/ssl/tasks/main.yml
@@ -14,11 +14,28 @@
 
 - name: Install OVH DNS API secrets file for ovh_zone
   template:
-    dest: "/etc/letsencrypt/ovh-dns-secrets/{{ ssl_ovh_zone }}.ini"
+    dest: "/etc/letsencrypt/ovh-dns-secrets/{{ cert_item.ssl_ovh_zone | default(ssl_ovh_zone) }}.ini"
     src: ovh-secrets.ini.j2
     owner: root
     group: root
     mode: 0600
+  with_items: "{{ ssl_certbot_certs }}"
+  loop_control:
+    loop_var: cert_item
+
+- name: Configure the post hook script
+  copy:
+    content: "{{ cert_item.post_hook_script }}"
+    owner: "root"
+    group: "root"
+    mode: 0755
+    dest: "{{ cert_item.post_hook_script_path }}"
+  when:
+    - cert_item.ssl_certbot_post_hook_script_path
+    - cert_item.ssl_certbot_post_hook_script
+  with_items: "{{ ssl_certbot_certs }}"
+  loop_control:
+    loop_var: cert_item
 
 - name: Install, configure and run certbot
   include_role:
@@ -29,10 +46,20 @@
     certbot_auto_renew_hour: "{{ ssl_certbot_auto_renew_hour }}"
     certbot_admin_email: "{{ ssl_certbot_admin_email }}"
     certbot_create_if_missing: "{{ ssl_certbot_create_if_missing }}"
-    certbot_create_command: "{{ certbot_script }} certonly --dns-ovh --dns-ovh-credentials /etc/letsencrypt/ovh-dns-secrets/{{ ssl_ovh_zone }}.ini --dns-ovh-propagation-seconds {{ ssl_ovh_propagation_seconds }} --noninteractive --agree-tos --email {{ cert_item.email | default(certbot_admin_email) }} -d {{ cert_item.domains | join(',') }} --expand"
+    certbot_create_command: >-
+      {{ certbot_script }} certonly
+      --dns-ovh --dns-ovh-credentials /etc/letsencrypt/ovh-dns-secrets/{{ cert_item.ssl_ovh_zone | default(ssl_ovh_zone) }}.ini
+      --dns-ovh-propagation-seconds {{ ssl_ovh_propagation_seconds }}
+      --noninteractive
+      --agree-tos
+      --email {{ cert_item.email | default(certbot_admin_email) }}
+      -d {{ cert_item.domains | join(',') }}
+      {{ ['--post-hook', cert_item.post_hook_script_path] | join(' ') if cert_item.post_hook_script_path and cert_item.post_hook_script else '' }}
+      --expand
     certbot_certs: "{{ ssl_certbot_certs }}"
 
 - name: Reload nginx after certificate installation
   service:
     name: nginx
     state: reloaded
+  when: ssl_reload_nginx_service | default(true)

--- a/roles/ssl/templates/ovh-secrets.ini.j2
+++ b/roles/ssl/templates/ovh-secrets.ini.j2
@@ -1,4 +1,4 @@
-dns_ovh_endpoint = {{ ssl_ovh_endpoint }}
-dns_ovh_application_key = {{ ssl_ovh_dns_api_app_key }}
-dns_ovh_application_secret = {{ ssl_ovh_dns_api_app_secret }}
-dns_ovh_consumer_key = {{ ssl_ovh_dns_api_consumer_key }}
+dns_ovh_endpoint = {{ cert_item.ssl_ovh_endpoint | default(ssl_ovh_endpoint) }}
+dns_ovh_application_key = {{ cert_item.ssl_ovh_dns_api_app_key | default(ssl_ovh_dns_api_app_key) }}
+dns_ovh_application_secret = {{ cert_item.ssl_ovh_dns_api_app_secret | default(ssl_ovh_dns_api_app_secret) }}
+dns_ovh_consumer_key = {{ cert_item.ssl_ovh_dns_api_consumer_key | default(ssl_ovh_dns_api_consumer_key) }}


### PR DESCRIPTION
La pull request change trois choses :


1. chaque cert_item peut définir ses propres clés d'API OVH
C'est utile pour déployer plusieurs configurations différentes sur un même serveur avec des clés par domaine et non pas une clé globale qui permettent de manipuler plusieurs domaines.

2. chaque cert_item peut définir un script bash à exécuter suite au renouvellement de son certificat
C'est utile pour redémarrer des services spécifiques, envoyer des notifications, etc.

3. Le service nginx managé par systemctl n'est pas systématiquement rechargé
C'est utile lorsque nginx est présent sous forme de container. Dans ce cas, le reload de nginx est à définir dans le script post hook


Exemple de configuration utilisée sur la nouvelle infrastructure de production d'annuaire-entreprises :
```
ssl_certbot_certs:
  - domains:
      - "{{ node_hostname }}"
      - "*.{{ node_hostname }}"

    ssl_ovh_zone: "{{ node_hostname }}"
    ssl_ovh_dns_api_app_key: "{{ ssl_ovh_dns_domains['api.gouv.fr'].api_app_key }}"
    ssl_ovh_dns_api_app_secret: "{{ ssl_ovh_dns_domains['api.gouv.fr'].api_app_secret }}"
    ssl_ovh_dns_api_consumer_key: "{{ ssl_ovh_dns_domains['api.gouv.fr'].api_consumer_key }}"

    post_hook_script_path: /etc/letsencrypt/renewal-hooks/post/{{ node_hostname }}
    post_hook_script: |
      #!/bin/sh

      docker exec -it nginx sh -c "nginx -s reload"

  - domains:
      - "recherche-entreprises.api.gouv.fr"
      - "sirene.recherche-entreprises.api.gouv.fr"

    ssl_ovh_zone: api.gouv.fr
    ssl_ovh_dns_api_app_key: "{{ ssl_ovh_dns_domains['api.gouv.fr'].api_app_key }}"
    ssl_ovh_dns_api_app_secret: "{{ ssl_ovh_dns_domains['api.gouv.fr'].api_app_secret }}"
    ssl_ovh_dns_api_consumer_key: "{{ ssl_ovh_dns_domains['api.gouv.fr'].api_consumer_key }}"

    post_hook_script_path: /etc/letsencrypt/renewal-hooks/post/api.gouv.fr
    post_hook_script: |
      #!/bin/sh

      docker exec -it nginx sh -c "nginx -s reload"

  - domains:
      - "annuaire-entreprises.data.gouv.fr"

    ssl_ovh_zone: data.gouv.fr
    ssl_ovh_dns_api_app_key: "{{ ssl_ovh_dns_domains['data.gouv.fr'].api_app_key }}"
    ssl_ovh_dns_api_app_secret: "{{ ssl_ovh_dns_domains['data.gouv.fr'].api_app_secret }}"
    ssl_ovh_dns_api_consumer_key: "{{ ssl_ovh_dns_domains['data.gouv.fr'].api_consumer_key }}"

    post_hook_script_path: /etc/letsencrypt/renewal-hooks/post/data.gouv.fr
    post_hook_script: |
      #!/bin/sh

      docker exec -it nginx sh -c "nginx -s reload"
```

Avec `{{ node_hostname }}` qui correspond à `v2-production-{{ instance_number }}.annuaire-entreprises.infra.api.gouv.fr`